### PR TITLE
Adds missing cable and shutter on shop

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -48448,6 +48448,7 @@
 	id = "gunshop";
 	name = "gunshop shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/service/gunshop)
 "hrI" = (
@@ -68066,6 +68067,7 @@
 	name = "gunshop shutters"
 	},
 /obj/item/pen,
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/service/gunshop)
 "mAq" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -35720,6 +35720,7 @@
 	name = "Gunshop Shutter";
 	id = "gunshop"
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/service/gunshop)
 "csq" = (
@@ -37349,12 +37350,12 @@
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	name = "Gunshop Shutter";
 	id = "gunshop"
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/service/gunshop)
 "cyb" = (
@@ -58862,6 +58863,7 @@
 	name = "Gunshop Shutter";
 	id = "gunshop"
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/service/gunshop)
 "kOu" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -32866,6 +32866,7 @@
 	id = "arms_dealer";
 	name = "gunshop shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "iNt" = (
@@ -38747,15 +38748,6 @@
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"kNW" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/window{
-	id = "arms_dealer";
-	name = "gunshop shutters"
-	},
-/turf/open/floor/wood/tile,
-/area/service/theater)
 "kOe" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -48218,6 +48210,7 @@
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "nNi" = (
@@ -60904,6 +60897,11 @@
 	dir = 8
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "arms_dealer";
+	name = "gunshop shutters"
+	},
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "rXQ" = (
@@ -118077,7 +118075,7 @@ avs
 fVE
 vst
 lJN
-kNW
+iNj
 tKm
 oGs
 flI


### PR DESCRIPTION
## About The Pull Request

I had forgotten a missing shutter on Metastations and additional cables on some Maps gunshop

## Changelog
:cl:
add: Adds missing shutter and cables on meta, delta and kilo on gunshop
/:cl:
